### PR TITLE
Update vpoller.c to compile with zabbix 6.0.X

### DIFF
--- a/extra/zabbix/vpoller-module/vpoller.c
+++ b/extra/zabbix/vpoller-module/vpoller.c
@@ -114,7 +114,11 @@ zbx_module_load_config(void)
     { NULL },
   };
   
-  parse_cfg_file(MODULE_CONFIG_FILE, cfg, ZBX_CFG_FILE_OPTIONAL, ZBX_CFG_STRICT);
+  /*
+   * A new paramter was added in zabbix 6.0 to reread the zabbix agent configuration without restarting it.
+   * see ZBXNEXT-6936
+   */
+  parse_cfg_file(MODULE_CONFIG_FILE, cfg, ZBX_CFG_FILE_OPTIONAL, ZBX_CFG_STRICT, ZBX_CFG_NO_EXIT_FAILURE);
 }
 
 /*


### PR DESCRIPTION
Fix to compile vpoller module with Zabbix 6.0
In Zabbix 6.0 a new parameter was introduced to reread the Zabbix agent without restarting it, so now it's required in the parse_cfg_file function.
You can check it under feature request ZBXNEXT-6936
